### PR TITLE
enhance settings system and path detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,12 @@ target/
 
 # Repository specific stuff
 release/
+
+# Editor files
+.vscode
+
+# Modded Entities
+resources/Entities/ModTemp
+
+# Settings files
+settings.ini


### PR DESCRIPTION
BR uses the Qt settings system in a way that doesn't
save settings properly between runs.
This fixes it so it uses a settings.ini file to determine various
settings, including but not limited to properly saving window state and
resource paths.

This also greatly enhances path detection. (at least on windows)
Starting from your steam install directory, BR will now intelligently
try to figure out your install location, and from that your resource and
mod paths. Additionally, it will now load your most recent stb
automatically at startup and try to save/load with the dialog from your
mod directory rather than your resources folder.

Also fixes a couple of minor bugs:
  - There was always the intent to overlay the default "no room loaded"
  background with a white overlay, but the way it was implemented didn't
  really come across. This makes the color much more obvious.
  - BR assumes difficulties 1-10 when displaying room names in the
  sidebar, which can actually lead to issues when loading the new
  difficulty 15 rooms added in the late boosters. This fixes that
  problem by scaling it to 15 and also prevents this from affecting
  future difficulty range tweaks.