### PR TITLE
add mod support to BR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,32 @@
 # Basement Renovator
 
-* Basement Renovator is a 3rd-party *[Binding of Isaac: Rebirth](https://store.steampowered.com/app/250900/The_Binding_of_Isaac_Rebirth/)* room and level editor.
+* Basement Renovator is a 3rd-party *[Binding of Isaac: Afterbirth(+)](https://store.steampowered.com/app/250900/The_Binding_of_Isaac_Rebirth/)* room and level editor.
+  * It will **not** edit *Rebirth* rooms. If you need to edit *Rebirth* floors for some reason, use an [older version](https://github.com/Tempus/Basement-Renovator/tree/a952cd030b0bf677e07a874ea7be901242a6505c).
 * It is open-source and written in [Python 3](https://www.python.org/).
-* It is much better than the room editor included with the game and is even used by the official staff to create new content.
+* It makes it easy to create rooms and is even used by official staff.
 * It was originally written by [Colin Naga](http://www.chronometry.ca/) and is now supported by the modding community.
-
-### Compatibility
-
-The current version will work on floor files for the *[Afterbirth](https://store.steampowered.com/app/401920/The_Binding_of_Isaac_Afterbirth/)* expansion and the *[Afterbirth+](https://store.steampowered.com/app/570660/The_Binding_of_Isaac_Afterbirth/)* expansion, but not for the base game (*Rebirth*). If you need to edit *Rebirth* floors for some reason, just use an [older version of the code](https://github.com/Tempus/Basement-Renovator/tree/a952cd030b0bf677e07a874ea7be901242a6505c).
 
 ### Downloads
 
-There are some older packaged downloads that are on the [releases tab](https://github.com/Tempus/Basement-Renovator/releases), but these are **out of date**. Please run Basement Renovator from source.
+  - There are some older packaged downloads that are on the [releases tab](https://github.com/Tempus/Basement-Renovator/releases), but these are **out of date**. Please run Basement Renovator from source as described below.
 
-### Running from Source (Windows)
+### Running from Source
 
-Perform the following steps in an **an elevated (administrator) command-shell**.
+1. Download a copy of the source code, either through git or using `Clone or download > Download zip`
 
-* Install [Chocolatey](https://chocolatey.org/):
-  * `@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"`
-* Install [Git](https://git-scm.com/) and [Python 3](https://www.python.org/):
-  * `choco install git python3 -y`
-  * `refreshenv`
-* Install the Python dependencies:
-  * `pip install pyqt5 psutil`
-* Clone the repository:
-  * `cd %userprofile%\Documents` <br />
-  (or wherever you want the repository to live) 
-  * `git clone https://github.com/Tempus/Basement-Renovator.git` <br />
-  (or clone a fork, if you are doing development work)
-* Run it:
-  * `cd Basement-Renovator`
-  * `python BasementRenovator.py`
+2. Install python 3 from the [Python website](https://www.python.org/downloads/) or whatever method you prefer. (apt, brew, chocolatey, etc.) Make sure to [check the box to] add Python to your PATH; if you don't, the next steps will
+complain about python command not existing. If you forget, rerun the installer to check the box. If you use another installation method, make sure you have *pip* (python package manager, used to grab dependencies)
 
-### Running from Source (macOS)
+3. Run `pip install pyqt5 psutil` from a console window. (cmd, powershell, a terminal, etc.) This installs some additional dependencies for BR.
 
-Perform the following steps in Terminal.
+4. Run `python BasementRenovator.py` from the console, make sure you run it in the BR folder.
+Alternatively, double click the script to run it. Errors and other messages will display in the console.
 
-* Install [brew](https://brew.sh/):
-  * `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
-* Install [Python 3](https://www.python.org/):
-  * `brew install python`
-* Install the Python dependencies:
-  * `pip3 install pyqt5 psutil`
-* Clone the repository:
-  * `cd ~/Documents/` <br />
-  (or wherever you want the repository to live) 
-  * `git clone https://github.com/Tempus/Basement-Renovator.git` <br />
-  (or clone a fork, if you are doing development work)
-* Run it:
-  * `cd Basement-Renovator`
-  * `python3 BasementRenovator.py`
+---
 
 ### How to Create a Mod that Modifies Rooms in the Vanilla Game
 
+* If you're working with Rebirth or Afterbirth, you must use [Rick's Unpacker](http://svn.gib.me/builds/rebirth/) to get STB files. Otherwise:
 * First, unpack the game's assets using the official unpacker.
   * On Windows: <br />
   `C:\Program Files (x86)\Steam\steamapps\common\The Binding of Isaac Rebirth\tools\ResourceExtractor\ResourceExtractor.exe` <br />
@@ -71,7 +44,7 @@ Perform the following steps in Terminal.
 
 ### How to Use the Interface
 
-* You will first want to use Basement Renovator to open a vanilla floor STB file in order to look around and get a feel for how it works. Follow the instructions in the "How to Create a Mod that Modifies Rooms in the Vanilla Game" section above.
+* You will first want to use Basement Renovator to open a vanilla floor STB file in order to look around and get a feel for how it works. Follow the instructions in the "How to Create a Mod that Modifies Rooms in the Vanilla Game" section above. Basement Renovator can read and save them directly, no need to convert to XML.
 
 * **The Editor**: Smack in the middle is the main editor. You can drag any entity in this editor by clicking it, or select multiple entities by dragging a box around them. You can move entities wherever you'd like in the room. You can cut or paste entities, using the menu or keyboard shortcuts, and you can delete them by selecting them and hitting backspace or delete. Alt-click an entity to replace it with the chosen entity in your palette. You can choose whether doors are active or inactive by double clicking them.
 
@@ -83,9 +56,44 @@ Perform the following steps in Terminal.
 
 * **Other Things**: You can show or hide the grid in the edit menu, or by pressing Cmd-G (Ctrl-G on win). You can pick up any of the docks, and move them to new areas, have them as floating windows, or stack them as tabs. There are a few other options in the View menu to give you some choices.
 
-* **Test Menu**: There's a really useful test feature in the menu bar. You can load up rooms to test easily anywhere in the Basement/Cellar, or in the start room directly. The start room only supports 1x1 rooms, however! Makes testing a breeze.
+* **Test Menu**: There's a really useful Test feature in the menu bar. You can load up rooms to test easily anywhere in the Basement/Cellar, or in the start room directly. The start room only supports 1x1 rooms, however! You must be running the legal steam version of BoI:Afterbirth to use this feature. Makes testing a breeze.
 
-### Community & Help
+---
 
-* If you find a bug or an issue, you can [open an issue](https://github.com/Tempus/Basement-Renovator/issues).
-* Many people in the modding community hang out in the #modding channel of the [BoI Discord server](https://discord.gg/isaac).
+### F.A.Q.
+
+*I found a bug!*
+
+- Please [open an issue on github](https://github.com/Tempus/Basement-Renovator/issues) (we may not see everything immediately since the project is community maintained, but they will be addressed)
+- If you need immediate help, many people in the modding community hang out in the **#modding** channel of the [BoI Discord server](https://discord.gg/isaac).
+
+*I found something new you don't have!*
+
+- Great, let us know! Create an issue as mentioned above and we'll take a look.
+
+*When is the next update?*
+
+- The project doesn't really do formal releases anymore. If you want to run BR, it's recommended you follow the steps above to run the mod directly from source. Resources are updated soon after the game updates, so be sure to grab the latest version when that happens!
+
+*Why can't I edit door position/custom room size/make random entities?*
+
+- All of these have no effect, make the game buggy, or crash, and are not included in this editor.
+
+*How do I add custom entities?*
+  - For Afterbirth+ mods, you're in luck! Create a folder named `basementrenovator` in your mod's root folder. (it must be within your overall mods folder to be detected) Inside that folder, create an `EntitiesMod.xml` file.
+This should use the same format as `resources/EntitiesAfterbirth.xml` and has all the same conventions. To make things slightly easier, Group will default to `(Mod) Your Mod Name` if left out for an entity.
+The Image path is relative to the basementrenovator folder within your mod. Finally, BR will only load *enabled* mods to reduce noise and startup time.
+
+    - If your entity has some offset from its actual grid location in-game, you can use the `PlaceVisual` attribute. Check `resources/EntitiesAfterbirth+` for some examples; it can either be `X,Y` in +/- grid squares of offset or precoded dynamic behaviors like `WallSnap`.
+    - If you have an entity that does not exist in your `entities2.xml` for some reason. (This is mostly relevant to helper entities used with [Stage API](https://github.com/Meowlala/BOIStageAPI15)) you can add `Metadata="1"` to your entity. Be sure you know what you're doing! This suppresses useful error messages and allows BR to load entities it normally wouldn't.
+
+  - If for some reason this is too much hassle, or you want to quickly create rooms with entities from large mods that don't have support, you can toggle the *Autogenerate mod content* setting.
+This will crawl mods' `content/entities2.xml` instead of the `basementrenovator` folder and work automagically without any additional work. HOWEVER this comes with a number of downsides:
+    - It has to generate BR images for every entity in the mod each time the program starts up. This makes it slightly slower, but worse than that is the way the image is selected.
+    For lack of a better technique, the first available frame of the default animation is used. This works fine for many things, but for entities like gapers which have a default body animation with the head as an overlay,
+    the image is very poor compared to a curated one.
+    - Entities are classified by Kind automatically, so if you need to specially classify something this won't be smart enough to detect it.
+    - Every entity (with a few exceptions like projectiles) the mod adds will show up in BR. All of them. Even the ones that make no sense.
+    - The techniques don't mix, and so you'll lose out on the pluses of the other option.
+
+    For these reasons this setting is not recommended. It's much cleaner to use the `basementrenovator` directory.


### PR DESCRIPTION
BR will now scan the mods folder for additional entities. It will only
check enabled mods to reduce clutter.

It also adds the option to autogenerate entries for enabled mods from
their entities2 xml. This is not recommended, but is included for
unsupported mods.