### PR TITLE
add save and test hooks, BR mod callbacks, enhance test methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * Basement Renovator is a 3rd-party *[Binding of Isaac: Afterbirth(+)](https://store.steampowered.com/app/250900/The_Binding_of_Isaac_Rebirth/)* room and level editor.
   * It will **not** edit *Rebirth* rooms. If you need to edit *Rebirth* floors for some reason, use an [older version](https://github.com/Tempus/Basement-Renovator/tree/a952cd030b0bf677e07a874ea7be901242a6505c).
 * It is open-source and written in [Python 3](https://www.python.org/).
-* It makes it easy to create rooms and it is even used by the game's official staff.
+* It makes it easy to create rooms and is even used by the game's official staff.
 * It was originally written by [Colin Naga](http://www.chronometry.ca/) and is now supported by the modding community.
 
 ### Downloads
@@ -14,9 +14,9 @@ There are some older packaged downloads on the [releases tab](https://github.com
 
 1. Download a copy of the source code, either through git or using `Clone or download > Download zip`
 
-2. Install Python 3 from the [Python website](https://www.python.org/downloads/) or from a package manager (apt, brew, Chocolatey, etc.). Make sure to check the box to add Python to your PATH; if you don't, the next steps will complain about `python` command not existing. If you forget, re-run the installer and check the box. If you use another installation method, make sure you have *pip* installed. (pip is the Python package manager, used to grab dependencies).
+2. Install Python 3 from the [Python website](https://www.python.org/downloads/) or from a package manager (apt, brew, chocolatey, etc.). Make sure to check the box to add Python to your PATH; if you don't, the next steps will complain about the `python` command not existing. If you forget, re-run the installer and check the box. If you use another installation method, make sure you have *pip* installed. (pip is the Python package manager, used to grab dependencies).
 
-3. Run `pip install pyqt5 psutil` (from cmd, Terminal, etc.) to install dependencies.
+3. Run `pip install pyqt5 psutil` (from cmd, terminal, etc.) to install dependencies.
 
 4. Double click the "BasementRenovator.py" script.
 
@@ -42,7 +42,7 @@ There are some older packaged downloads on the [releases tab](https://github.com
 
 ### How to Use the Interface
 
-* You will first want to use Basement Renovator to open a vanilla floor STB file in order to look around and get a feel for how it works. Follow the instructions in the "How to Create a Mod that Modifies Rooms in the Vanilla Game" section above. Basement Renovator can read and save them directly, no need to convert to XML.
+* You'll first want to use Basement Renovator to open a vanilla floor STB file in order to look around and get a feel for how it works. Follow the instructions in the "How to Create a Mod that Modifies Rooms in the Vanilla Game" section above. Basement Renovator can read and save them directly, no need to convert to XML.
 
 * **The Editor**: Smack in the middle is the main editor. You can drag any entity in this editor by clicking it, or select multiple entities by dragging a box around them. You can move entities wherever you'd like in the room. You can cut or paste entities, using the menu or keyboard shortcuts, and you can delete them by selecting them and hitting backspace or delete. Alt-click an entity to replace it with the chosen entity in your palette. You can choose whether doors are active or inactive by double clicking them.
 
@@ -63,7 +63,7 @@ There are some older packaged downloads on the [releases tab](https://github.com
 *I found a bug!*
 
 * Please [open an issue on github](https://github.com/Tempus/Basement-Renovator/issues).
-* If you need immediate help, many people in the modding community hang out in the **#modding** channel of the [BoI Discord server](https://discord.gg/isaac).
+* If you need immediate help, many people in the modding community hang out in the **#modding** channel of the [BoI Discord server.](https://discord.gg/isaac)
 
 *When is the next update?*
 
@@ -75,9 +75,9 @@ There are some older packaged downloads on the [releases tab](https://github.com
 
 *How do I add custom entities?*
 
-* This will only work for Afterbirth+ mods. Create a folder named `basementrenovator` in your mod's root folder. (It must be within your overall mods folder to be detected.) Inside that folder, create an `EntitiesMod.xml` file. This should use the same format as `resources/EntitiesAfterbirth.xml` and have the same conventions. If `Group` is left out, it will default to `(Mod) Your Mod Name`. The `Image` path is relative to the `basementrenovator` folder within your mod. Finally, BR will only load *enabled* mods to reduce noise and startup time.
-* If your entity has some offset from its actual grid location in-game, you can use the `PlaceVisual` attribute. Check `resources/EntitiesAfterbirth+` for some examples. It can either be `X,Y` in +/- grid squares of offset or precoded dynamic behaviors like `WallSnap`.
-* If you have an entity that does not exist in your `entities2.xml` for some reason, you can add `Metadata="1"` to your entity. Be sure you know what you're doing! This suppresses useful error messages and allows BR to load entities it normally wouldn't. (This kind of thing is mostly relevant to helper entities used with [Stage API](https://github.com/Meowlala/BOIStageAPI15).)
+* This will only work for Afterbirth+ mods. Create a folder named `basementrenovator` in your mod's root folder. (It must be within your overall mods folder to be detected.) Inside that folder, create an `EntitiesMod.xml` file. This should use the same format as `resources/EntitiesAfterbirthPlus.xml` and have the same conventions. If `Group` is left out, it will default to `(Mod) Your Mod Name`. The `Image` path is relative to the `basementrenovator` folder within your mod. Finally, BR will only load *enabled* mods to reduce noise and startup time.
+* If your entity has some offset from its actual grid location in-game, you can use the `PlaceVisual` attribute. Check `resources/EntitiesAfterbirthPlus` for some examples. It can either be `X,Y` in +/- grid squares of offset or precoded dynamic behaviors like `WallSnap`.
+* If you have an entity that does not exist in your `entities2.xml` for some reason, you can add `Metadata="1"` to your entity. Be sure you know what you're doing! This suppresses useful error messages and allows BR to load entities it normally wouldn't. (This kind of thing is mostly relevant to helper entities used with [Stage API](https://github.com/Meowlala/BOIStageAPI15))
 * If for some reason this is too much hassle, or you want to quickly create rooms with entities from large mods that don't have support, you can toggle the *Autogenerate mod content* setting. This will crawl mods' `content/entities2.xml` instead of the `basementrenovator` folder and work automagically without any additional work. HOWEVER this comes with a number of downsides:
   * It has to generate BR images for every entity in the mod each time the program starts up. This makes it slightly slower, but worse than that is the way the image is selected. For lack of a better technique, the first available frame of the default animation is used. This works fine for many things, but for entities like gapers which have a default body animation with the head as an overlay, the image is very poor compared to a curated one.
   * Entities are classified by Kind automatically, so if you need to specially classify something this won't be smart enough to detect it.
@@ -92,3 +92,13 @@ There are some older packaged downloads on the [releases tab](https://github.com
   - Subtypes are represented using 8 bits, or the range 0 - 255. This is the same both in BR and in game. Follows the same rules as variant otherwise.
 
   If you see this warning, please change your values to fit in the proper range. This will prevent a lot of difficult to debug issues in your mods. You can see exactly where an entity is out of range in the logs or in the tooltip if you hover over it in the room.
+
+*What is a hook?*
+
+* Certain work patterns in Basement Renovator require repeatedly taking an outputted file and performing a manual process on it. The most prominent example of this is the AB+ mod [Stage API](https://github.com/Meowlala/BOIStageAPI15) which requires stbs to be converted to lua files in order for it to properly use them.
+* As such a process is error prone and tedious, BR allows users to set up lists of scripts that will be executed on relevant files at various points before it finishes processing them.
+  - Save Hook: when a room file is saved, all of these scripts are run with the resulting stb like so: `script.exe "path to file" --save" The bonus --save argument can be used if it's desirable to reuse a single script file.
+    - Stage API uses this to convert stbs to lua files every time you save them
+  - Test Hook: when a room is tested, it is output to an xml file. This xml file is passed to a script like so: `script.exe "path to file" --test`
+    - Stage API uses this to set up a test room file when testing rooms
+* You can add hooks in File > Set Hooks

--- a/resources/modtemplate/main.lua
+++ b/resources/modtemplate/main.lua
@@ -1,0 +1,117 @@
+
+BasementRenovator = BasementRenovator or { subscribers = {} }
+BasementRenovator.mod = RegisterMod('BasementRenovator', 1)
+
+local function log(msg)
+    msg = '[BasementRenovator] ' .. tostring(msg)
+    print(msg)
+    Isaac.DebugString(msg)
+end
+
+local function fireCallback(name, ...)
+    for _, sub in pairs(BasementRenovator.subscribers) do
+        callback = sub[name]
+        if callback then
+            local result = callback(...)
+            if result ~= nil then return result end
+        end
+    end
+end
+
+local success, data = pcall(require, 'roomTest')
+if success then
+    BasementRenovator.testRoom = data
+else
+    log(data) -- error
+end
+
+if not BasementRenovator.testRoom then
+    log('No room to test; please disable the mod')
+    return
+else
+    local room = BasementRenovator.testRoom
+    log('TEST METHOD: ' .. BasementRenovator.testRoom.TestType)
+    log('TEST STAGE: ' .. room.Stage .. '.' .. room.StageType)
+    log('TEST ROOM: ' .. room.Type .. '.' .. room.Variant .. '.' .. room.Subtype)
+end
+
+function BasementRenovator:InTestRoom()
+    local test = BasementRenovator.testRoom
+
+    local t, v, s = test.Type, test.Variant, test.Subtype
+
+    local level = Game():GetLevel()
+    local desc = level:GetCurrentRoomDesc()
+    local data = desc.Data
+    if data.Type == t and data.Variant == v and data.Subtype == s then
+        return desc
+    end
+end
+
+local badShapes = {
+    [2] = true,
+    [3] = true,
+    [5] = true, 
+    [7] = true
+}
+BasementRenovator.mod:AddCallback(ModCallbacks.MC_POST_CURSE_EVAL, function(_, curse)
+    local test = BasementRenovator.testRoom
+
+    if test.TestType == 'StageReplace' and badShapes[test.Shape] then
+        log('Forcing XL due to room shape!')
+        return curse | LevelCurse.CURSE_OF_LABYRINTH
+    end
+end)
+
+BasementRenovator.mod:AddCallback(ModCallbacks.MC_POST_GAME_STARTED, function()
+    local test = BasementRenovator.testRoom
+
+    if test.TestType == 'StageReplace' then
+        Game():GetPlayer(0):AddCollectible(CollectibleType.COLLECTIBLE_MIND, 0, false)
+        Game():GetSeeds():AddSeedEffect(SeedEffect.SEED_PREVENT_CURSE_LOST)
+    end
+end)
+
+local typeToSuffix = {
+    [StageType.STAGETYPE_ORIGINAL] = "",
+    [StageType.STAGETYPE_WOTL] = "a",
+    [StageType.STAGETYPE_AFTERBIRTH] = "b"
+}
+BasementRenovator.mod:AddCallback(ModCallbacks.MC_POST_CURSE_EVAL, function()
+    local test = BasementRenovator.testRoom
+    -- For whatever reasons, callbacks execute when the stage command is run from the console,
+    -- but don't when used from lua
+    -- This may be patched in Rep, so fix this then so the callback doesn't happen twice
+    -- Use CURSE_EVAL because otherwise it'll usually happen after other level detection code
+
+    if test.TestType ~= 'InstaPreview' then
+        local level = Game():GetLevel()
+        if not (level:GetStage() == test.Stage and
+                level:GetStageType() == test.StageType) then
+
+            local stage, type = test.Stage, test.StageType
+            type = typeToSuffix[type] or ''
+
+            Isaac.ExecuteCommand('stage ' .. stage .. type)
+        end
+    end
+
+    fireCallback('TestStage', BasementRenovator.testRoom)
+end)
+
+BasementRenovator.mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
+    local desc = BasementRenovator:InTestRoom()
+    if desc then
+        fireCallback('TestRoom', BasementRenovator.testRoom, desc)
+    end
+end)
+
+BasementRenovator.mod:AddCallback(ModCallbacks.MC_PRE_ROOM_ENTITY_SPAWN, function(_, ...)
+    local desc = BasementRenovator:InTestRoom()
+    if desc then
+        local replacement = fireCallback('TestRoomEntitySpawn', BasementRenovator.testRoom, desc, ...)
+        if replacement then
+            return replacement
+        end
+    end
+end)

--- a/resources/modtemplate/metadata.xml
+++ b/resources/modtemplate/metadata.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+    <!-- mods resources are loaded in reverse ascii order, we need to be the authority -->
+    <name>!!!!!!basement-renovator-helper</name>
+    <directory>basement-renovator-helper</directory>
+    <description>
+        Used by Basement Renovator for mod related things.
+        
+        Replaces resources stbs to load test rooms in the starting room and basement
+        
+        Mods can subscribe to the TestRoom callback to get notified when the player enters a test room like so:
+        ```lua
+            BasementRenovator = BasementRenovator or { subscribers = {} }
+            table.insert(BasementRenovator.subscribers, {
+                name = 'TestRoom',
+                callback = function(room)
+                    --...
+                end
+            })
+        ```
+
+        BRTestData object:
+        {
+            TestType = ('InstaPreview', 'StageReplace', or 'StartingRoom'),
+            Stage = (LevelStage value),
+            StageType = (StageType value),
+            Type = (RoomDesc Data type),
+            Variant = (RoomDesc Data variant),
+            Subtype = (RoomDesc Data subtype),
+            Shape = (RoomShape value)
+        }
+
+        Callback List:
+            - TestRoom (BRTestData, RoomDesc)
+                - Executes during post new room when the room matches the BR test room
+            - TestEntitySpawn (BRTestData, RoomDesc, ...PRE_ROOM_ENTITY_SPAWN params)
+                - Executes during pre room entity spawn in the test room. (occurs before the TestRoom callback)
+                - Can return a new entity with the same semantics as the normal callback
+                - Will stop firing after any subscription returns a value
+            - TestStage (BRTestData)
+                - Executes during post curse eval when the floor matches the test floor
+    </description>
+</metadata>


### PR DESCRIPTION
Hooks are a list of scripts that get called when a BR action happens.
This implements hooks for saving and starting a room test.

To go with the test hooks, the BR helper mod is now formalized and has a
lua component that has callbacks. This is the first half of
compatibility with stage api.

Improves the basement replacement test method; it now can replace
whatever floor's files are relevant. It and starting room will now also
change stage as appropriate when the game starts.

Stage Replacement tests also now force the floor to be XL, turns off
Curse of the Lost, and gives the player The Mind to make reset scumming
easier.

Instapreview now supports steam urls

Add blue womb and fix cathedral and sheol for instapreview; the ids
weren't updated after rebirth and blue womb took their old id