### PR TITLE
add recompute (sort + compact) room variants

### DIFF
--- a/NicheFeatures.md
+++ b/NicheFeatures.md
@@ -15,3 +15,7 @@ Occasionally you may decide to move certain rooms to another file, or want copie
 
 ### Better Bulk Replace Entities
 Did you know that when bulk replacing entities, the "replaced" entity is based on your currently selected entity in the room, and the "replacement" entity is based on your currently selected entity in the palette? This can save some time when performing this process as you don't have to remember the actual ids. Additionally, leaving the variants and/or subtypes as -1 will either match any, for the replaced entity, or preserve the original value, for the replacement.
+
+### Recompute Room IDs
+Ever have a room file where the organization has completely gotten away from you and everything is completely out of order? This fixes that by reordering all your rooms and changing their variants to all be next to each other.
+


### PR DESCRIPTION
Add ability to "recompute" room variants, which sorts them and then
renumbers them linearly starting from the first variant

Fix a bug where the editor would "hop" after replacing entities with a
room visible

Fix a small bug with door prefix sorting