### PR TITLE
add rebirth stb compatibility

### DIFF
--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -3721,9 +3721,10 @@ class MainWindow(QMainWindow):
         self.fc = f.addAction('Open',          		self.openMap, QKeySequence("Ctrl+O"))
         self.fb = f.addAction('Open by Stage',      self.openMapDefault, QKeySequence("Ctrl+Shift+O"))
         f.addSeparator()
-        self.fd = f.addAction('Save',               self.saveMap, QKeySequence("Ctrl+S"))
-        self.fe = f.addAction('Save As...',         self.saveMapAs, QKeySequence("Ctrl+Shift+S"))
-        self.fk = f.addAction('Export to STB',      self.exportSTB, QKeySequence("Shift+Alt+S"))
+        self.fd = f.addAction('Save',                     self.saveMap, QKeySequence("Ctrl+S"))
+        self.fe = f.addAction('Save As...',               self.saveMapAs, QKeySequence("Ctrl+Shift+S"))
+        self.fk = f.addAction('Export to STB',            lambda: self.exportSTB(), QKeySequence("Shift+Alt+S"))
+        self.fk = f.addAction('Export to STB (Rebirth)',  lambda: self.exportSTB(stbType="Rebirth"))
         f.addSeparator()
         self.fk = f.addAction('Copy Screenshot to Clipboard', lambda: self.screenshot('clipboard'), QKeySequence("F10"))
         self.fg = f.addAction('Save Screenshot to File...', lambda: self.screenshot('file'), QKeySequence("Ctrl+F10"))
@@ -4098,7 +4099,7 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "Error", "Failed opening rooms. The file does not exist.")
         except NotImplementedError:
             traceback.print_exception(*sys.exc_info())
-            QMessageBox.warning(self, "Error", "This is not a valid Afterbirth+ STB file. It may be a Rebirth STB, or it may be one of the prototype STB files accidentally included in the AB+ release.")
+            QMessageBox.warning(self, "Error", "This is not a valid STB file. (i.e. Rebirth or Afterbirth format) It may be one of the prototype STB files accidentally included in the AB+ release.")
         except:
             traceback.print_exception(*sys.exc_info())
             QMessageBox.warning(self, "Error", f"Failed opening rooms.\n{''.join(traceback.format_exception(*sys.exc_info()))}")
@@ -4129,7 +4130,7 @@ class MainWindow(QMainWindow):
         elif ext == '.txt':
             rooms = StageConvert.txtToCommon(path, entityXML)
         else:
-            rooms = StageConvert.stbABToCommon(path)
+            rooms = StageConvert.stbToCommon(path)
 
         seenSpawns = {}
         for room in rooms:
@@ -4198,7 +4199,7 @@ class MainWindow(QMainWindow):
     def saveMapAs(self):
         self.saveMap(True)
 
-    def exportSTB(self):
+    def exportSTB(self, stbType=None):
         target = self.path
 
         if not target:
@@ -4207,12 +4208,12 @@ class MainWindow(QMainWindow):
 
         try:
             target = os.path.splitext(target)[0] + ".stb"
-            self.save(self.roomList.getRooms(), target, updateRecent=False)
+            self.save(self.roomList.getRooms(), target, updateRecent=False, stbType=stbType)
         except:
             traceback.print_exception(*sys.exc_info())
             QMessageBox.warning(self, "Error", f"Exporting failed.\n{''.join(traceback.format_exception(*sys.exc_info()))}")
 
-    def save(self, rooms, path=None, updateRecent=True, isPreview=False):
+    def save(self, rooms, path=None, updateRecent=True, isPreview=False, stbType=None):
         path = path or (os.path.splitext(self.path)[0] + '.xml')
 
         self.storeEntityList()
@@ -4233,7 +4234,10 @@ class MainWindow(QMainWindow):
         if ext == '.xml':
             StageConvert.commonToXML(path, rooms, isPreview=isPreview)
         else:
-            StageConvert.commonToSTBAB(path, rooms)
+            if stbType == 'Rebirth':
+                StageConvert.commonToSTBRB(path, rooms)
+            else:
+                StageConvert.commonToSTBAB(path, rooms)
 
 
         if updateRecent and ext == '.xml':

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Basement Renovator
 
 * Basement Renovator is a 3rd-party *[Binding of Isaac: Afterbirth(+)](https://store.steampowered.com/app/250900/The_Binding_of_Isaac_Rebirth/)* room and level editor.
-  * It will **not** edit *Rebirth* rooms. If you need to edit *Rebirth* floors for some reason, use an [older version](https://github.com/Tempus/Basement-Renovator/tree/a952cd030b0bf677e07a874ea7be901242a6505c).
+  * It will edit Rebirth rooms, but some entity IDs may be incorrect. If you need to edit Rebirth rooms for some reason and require perfect correctness, use an [older version](https://github.com/Tempus/Basement-Renovator/tree/a952cd030b0bf677e07a874ea7be901242a6505c). (most entities should be fine in the current version, but just to be safe)
 * It is open-source and written in [Python 3](https://www.python.org/).
 * It makes it easy to create rooms and is even used by the game's official staff.
 * It was originally written by [Colin Naga](http://www.chronometry.ca/) and is now supported by the modding community.


### PR DESCRIPTION
This isn't full rebirth compatibility, as it still shows all the
afterbirth ents and doesn't account for adjusted entity ids.
This would be a much bigger undertaking, (particularly requiring
and overhaul in how the data xmls are handled) and may be done later.

add fallback shape 0 code for afterbirth stbs with null rooms