### PR TITLE
Allow for creating modded room subtypes

### DIFF
--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -3335,6 +3335,8 @@ class RoomSelector(QWidget):
     def changeSubtype(self, var):
         for r in self.selectedRooms():
             r.info.subtype = var
+            r.setRoomBG()
+
             r.setToolTip()
         mainWindow.dirt()
         mainWindow.scene.update()

--- a/src/lookup.py
+++ b/src/lookup.py
@@ -64,29 +64,63 @@ def parseCriteria(txt):
 
 
 def applyGfxReplacement(replacement, gfxchildren):
-    for origgfx, newgfx in zip_longest(replacement.findall("Gfx"), gfxchildren):
-        if newgfx is None:
-            continue
-        elif origgfx is None:
+    alloriggfx = replacement.findall("Gfx")
+
+    for newgfx in gfxchildren:
+        found = False
+
+        for origgfx in alloriggfx:
+            newSubtype = newgfx.get("Subtype", "0")
+            origSubtype = origgfx.get("Subtype", "0")
+
+            if newSubtype == origSubtype:
+                found = True
+
+                for key, val in newgfx.attrib.items():
+                    origgfx.set(key, val)
+
+                for ent in newgfx.findall("Entity"):
+                    origent = None
+                    for orig in origgfx.findall(f'Entity[@ID="{ent.get("ID")}"]'):
+                        if orig.get("Variant", "0") == ent.get("Variant", "0") and orig.get(
+                            "SubType", "0"
+                        ) == ent.get("SubType", "0"):
+                            origent = orig
+                            break
+                    if origent is not None:
+                        for key, val in ent.attrib.items():
+                            origent.set(key, val)
+                    else:
+                        origgfx.append(ent)
+
+                break
+
+        if not found:
             replacement.append(newgfx)
-            continue
 
-        for key, val in newgfx.attrib.items():
-            origgfx.set(key, val)
+    # for origgfx, newgfx in zip_longest(replacement.findall("Gfx"), gfxchildren):
+    #     if newgfx is None:
+    #         continue
+    #     elif origgfx is None:
+    #         replacement.append(newgfx)
+    #         continue
 
-        for ent in newgfx.findall("Entity"):
-            origent = None
-            for orig in origgfx.findall(f'Entity[@ID="{ent.get("ID")}"]'):
-                if orig.get("Variant", "0") == ent.get("Variant", "0") and orig.get(
-                    "SubType", "0"
-                ) == ent.get("SubType", "0"):
-                    origent = orig
-                    break
-            if origent is not None:
-                for key, val in ent.attrib.items():
-                    origent.set(key, val)
-            else:
-                origgfx.append(ent)
+    #     for key, val in newgfx.attrib.items():
+    #         origgfx.set(key, val)
+
+    #     for ent in newgfx.findall("Entity"):
+    #         origent = None
+    #         for orig in origgfx.findall(f'Entity[@ID="{ent.get("ID")}"]'):
+    #             if orig.get("Variant", "0") == ent.get("Variant", "0") and orig.get(
+    #                 "SubType", "0"
+    #             ) == ent.get("SubType", "0"):
+    #                 origent = orig
+    #                 break
+    #         if origent is not None:
+    #             for key, val in ent.attrib.items():
+    #                 origent.set(key, val)
+    #         else:
+    #             origgfx.append(ent)
 
 
 class Lookup(metaclass=abc.ABCMeta):

--- a/src/lookup.py
+++ b/src/lookup.py
@@ -98,30 +98,6 @@ def applyGfxReplacement(replacement, gfxchildren):
         if not found:
             replacement.append(newgfx)
 
-    # for origgfx, newgfx in zip_longest(replacement.findall("Gfx"), gfxchildren):
-    #     if newgfx is None:
-    #         continue
-    #     elif origgfx is None:
-    #         replacement.append(newgfx)
-    #         continue
-
-    #     for key, val in newgfx.attrib.items():
-    #         origgfx.set(key, val)
-
-    #     for ent in newgfx.findall("Entity"):
-    #         origent = None
-    #         for orig in origgfx.findall(f'Entity[@ID="{ent.get("ID")}"]'):
-    #             if orig.get("Variant", "0") == ent.get("Variant", "0") and orig.get(
-    #                 "SubType", "0"
-    #             ) == ent.get("SubType", "0"):
-    #                 origent = orig
-    #                 break
-    #         if origent is not None:
-    #             for key, val in ent.attrib.items():
-    #                 origent.set(key, val)
-    #         else:
-    #             origgfx.append(ent)
-
 
 class Lookup(metaclass=abc.ABCMeta):
     def __init__(self, prefix, version):


### PR DESCRIPTION
Before, creating a RoomTypesMod.xml only allowed you to completely replace the room gfx. Now it compares the subtype of the new room gfx entry with the previous ones to check if it should replace it or add the new room gfx entry. This allows people to add variants of existing room types by only changing the subtype.