### PR TITLE
Room Subtype is factored when sorting rooms

### DIFF
--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -6350,10 +6350,10 @@ class MainWindow(QMainWindow):
         )
 
     def sortRoomIDs(self):
-        self.sortRoomsByKey(lambda x: (x.info.type, x.info.variant))
+        self.sortRoomsByKey(lambda x: (x.info.type, x.info.subtype, x.info.variant))
 
     def sortRoomNames(self):
-        self.sortRoomsByKey(lambda x: (x.info.type, x.name, x.info.variant))
+        self.sortRoomsByKey(lambda x: (x.info.type, x.info.subtype, x.name,  x.info.variant))
 
     def sortRoomsByKey(self, key):
         roomList = self.roomList.list

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -6353,7 +6353,9 @@ class MainWindow(QMainWindow):
         self.sortRoomsByKey(lambda x: (x.info.type, x.info.subtype, x.info.variant))
 
     def sortRoomNames(self):
-        self.sortRoomsByKey(lambda x: (x.info.type, x.info.subtype, x.name, x.info.variant))
+        self.sortRoomsByKey(
+            lambda x: (x.info.type, x.info.subtype, x.name, x.info.variant)
+        )
 
     def sortRoomsByKey(self, key):
         roomList = self.roomList.list

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -6353,7 +6353,7 @@ class MainWindow(QMainWindow):
         self.sortRoomsByKey(lambda x: (x.info.type, x.info.subtype, x.info.variant))
 
     def sortRoomNames(self):
-        self.sortRoomsByKey(lambda x: (x.info.type, x.info.subtype, x.name,  x.info.variant))
+        self.sortRoomsByKey(lambda x: (x.info.type, x.info.subtype, x.name, x.info.variant))
 
     def sortRoomsByKey(self, key):
         roomList = self.roomList.list


### PR DESCRIPTION
Room Subtype is used for a wide variety of important distinctions in Repentance, such as: Mirror/White Fire rooms in Downpour, Button/Mineshaft rooms in Mines, Marked Skull rooms in Chapter 3. floors in Ascent

It is convenient and helpful to include Subtype into room sorting so these layout types are batched together