### PR TITLE
Add second check for if content-repentogon/entities2.xml exists

### DIFF
--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -139,33 +139,11 @@ from src.lookup import EntityLookup, MainLookup
 import src.anm2 as anm2
 from src.constants import *
 from src.util import *
+from src.version import *
 
 ########################
 #       XML Data       #
 ########################
-
-
-def getGameVersion():
-    """
-    Returns the current compatibility mode, and the sub version if it exists
-    """
-    # default mode if not set
-    mode = settings.value("CompatibilityMode", "Repentance+")
-
-    return mode
-
-
-def willLaunchREPENTOGON():
-    exePath: str | None = settings.value("CustomExePath")
-    return exePath and exePath.lower().endswith("repentogonlauncher.exe")
-
-
-def canUseREPENTOGON():
-    if getGameVersion() != "Repentance+":
-        return False
-
-    return willLaunchREPENTOGON()
-
 
 STEAM_PATH = None
 

--- a/src/lookup.py
+++ b/src/lookup.py
@@ -1429,6 +1429,14 @@ class MainLookup:
                     except ET.ParseError as e:
                         printf(f'ERROR parsing entities2 xml for mod "{modName}": {e}')
                         return
+                else:
+                    entities2Path = os.path.join(modPath, "content-repentogon/entities2.xml")
+                    try:
+                        self.entities2root = ET.parse(entities2Path).getroot()
+                    except ET.ParseError as e:
+                        printf(f'ERROR parsing entities2 xml for mod "{modName}": {e}')
+                        return
+
 
     def __init__(self, version, verbose):
         self.basemod = self.ModConfig()

--- a/src/lookup.py
+++ b/src/lookup.py
@@ -10,6 +10,7 @@ from src.constants import *
 from src.core import Entity
 from src.entitiesgenerator import generateXMLFromEntities2
 from src.util import *
+from src.version import *
 
 
 def loadXMLFile(path):
@@ -1429,7 +1430,7 @@ class MainLookup:
                     except ET.ParseError as e:
                         printf(f'ERROR parsing entities2 xml for mod "{modName}": {e}')
                         return
-                else:
+                elif canUseREPENTOGON():
                     entities2Path = os.path.join(
                         modPath, "content-repentogon/entities2.xml"
                     )

--- a/src/lookup.py
+++ b/src/lookup.py
@@ -1430,13 +1430,14 @@ class MainLookup:
                         printf(f'ERROR parsing entities2 xml for mod "{modName}": {e}')
                         return
                 else:
-                    entities2Path = os.path.join(modPath, "content-repentogon/entities2.xml")
+                    entities2Path = os.path.join(
+                        modPath, "content-repentogon/entities2.xml"
+                    )
                     try:
                         self.entities2root = ET.parse(entities2Path).getroot()
                     except ET.ParseError as e:
                         printf(f'ERROR parsing entities2 xml for mod "{modName}": {e}')
                         return
-
 
     def __init__(self, version, verbose):
         self.basemod = self.ModConfig()

--- a/src/version.py
+++ b/src/version.py
@@ -1,0 +1,25 @@
+from PyQt5.QtCore import QSettings
+
+
+def getGameVersion():
+    """
+    Returns the current compatibility mode, and the sub version if it exists
+    """
+    # default mode if not set
+    settings = QSettings("settings.ini", QSettings.IniFormat)
+    mode = settings.value("CompatibilityMode", "Repentance+")
+
+    return mode
+
+
+def willLaunchREPENTOGON():
+    settings = QSettings("settings.ini", QSettings.IniFormat)
+    exePath: str | None = settings.value("CustomExePath")
+    return exePath and exePath.lower().endswith("repentogonlauncher.exe")
+
+
+def canUseREPENTOGON():
+    if getGameVersion() != "Repentance+":
+        return False
+
+    return willLaunchREPENTOGON()


### PR DESCRIPTION
Repentogon has added a feature where mods can put their xml content in "content-repentogon" instead of "content", preventing it from loading if Repentogon is absent.

When BR searches for a mod's entities2.xml file, it should account for this, checking for it in content-repentogon if the entities2 in content does not exist.